### PR TITLE
[#21] Fix collapsing effect while scrolling a body with small size

### DIFF
--- a/shared/src/commonMain/kotlin/ui/screen/detail/PostDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/ui/screen/detail/PostDetailScreen.kt
@@ -19,10 +19,12 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.requiredWidthIn
@@ -41,6 +43,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -96,22 +99,26 @@ fun PostDetailContent(
             )
         },
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(scrollState)
-                .padding(it),
-        ) {
-            if (errorMessage != null) {
-                ErrorContent(errorMessage)
-            } else {
-                PostDetailContent(
-                    isLoading = isLoading,
-                    title = post?.title ?: "",
-                    author = post?.author ?: "",
-                    content = post?.content ?: "",
-                    modifier = Modifier.padding(16.dp),
-                )
+        BoxWithConstraints(Modifier.fillMaxSize()) {
+            val bodyMinHeight = remember(maxHeight) { maxHeight + 250.dp }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .padding(it),
+            ) {
+                if (errorMessage != null) {
+                    ErrorContent(errorMessage)
+                } else {
+                    PostDetailContent(
+                        isLoading = isLoading,
+                        title = post?.title ?: "",
+                        author = post?.author ?: "",
+                        content = post?.content ?: "",
+                        modifier = Modifier.padding(16.dp).heightIn(min = bodyMinHeight),
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #21: Fix collapsing effect while scrolling a body with small size

https://github.com/PatilShreyas/Foodium-KMM/assets/19620536/f3dab07c-08ac-41c0-861b-49e9075a1066

